### PR TITLE
Fix up protocol issues

### DIFF
--- a/client.js
+++ b/client.js
@@ -19,7 +19,7 @@ const _request = (pathOrUrl, opt, cb) => {
 	const {
 		verifyAlpnId,
 	} = {
-		verifyAlpnId: alpnId => alpnId === ALPN_ID,
+		verifyAlpnId: alpnId => alpnId ? (alpnId === ALPN_ID) : true,
 		...opt,
 	}
 
@@ -163,8 +163,9 @@ const sendGeminiRequest = (pathOrUrl, opt, done) => {
 		hostname: target.hostname || 'localhost',
 		port: target.port || DEFAULT_PORT,
 		tlsOpt,
-		verifyAlpnId,
 	}
+
+	if (verifyAlpnId) reqOpt.verifyAlpnId = verifyAlpnId
 
 	let cb = (err, res) => {
 		if (err) return done(err)

--- a/client.js
+++ b/client.js
@@ -59,7 +59,7 @@ const _request = (pathOrUrl, opt, cb) => {
 		})
 
 		// send request
-		socket.end(encodeURI(pathOrUrl) + ' \r\n')
+		socket.end(pathOrUrl + '\r\n')
 	})
 }
 
@@ -127,6 +127,7 @@ const sendGeminiRequest = (pathOrUrl, opt, done) => {
 		letUserConfirmClientCertUsage,
 		clientCertStore,
 		tlsOpt,
+		verifyAlpnId,
 	} = {
 		followRedirects: false,
 		// https://gemini.circumlunar.space/docs/spec-spec.txt, 1.4.3
@@ -162,6 +163,7 @@ const sendGeminiRequest = (pathOrUrl, opt, done) => {
 		hostname: target.hostname || 'localhost',
 		port: target.port || DEFAULT_PORT,
 		tlsOpt,
+		verifyAlpnId,
 	}
 
 	let cb = (err, res) => {

--- a/connect.js
+++ b/connect.js
@@ -28,7 +28,8 @@ const connectToGeminiServer = (opt, cb) => {
 	const socket = connectTls({
 		ALPNProtocols: [ALPN_ID],
 		minVersion: MIN_TLS_VERSION,
-		hostname, port,
+		host: hostname,
+		port,
 		cert, key, passphrase,
 		...tlsOpt,
 	})


### PR DESCRIPTION
- Got rid of URI encoding for URL, that doesn't seem to be in the spec
- Pass down `verifyAlpnId` option. Looks like servers aren't setting the APLD and it's yielding `false`.
- [tls.connect(options)](https://nodejs.org/api/tls.html#tls_tls_connect_options_callback) takes the hostname under the `host` property. Thus connections were always going to localhost.

With these changes, it all seems to work.
In my tests I set `verifyAlpnID` to `() => true` to permit all ALPNs