### PR TITLE
Remove ALPN protocols for issue #5

### DIFF
--- a/server.js
+++ b/server.js
@@ -85,6 +85,9 @@ const createGeminiServer = (opt = {}, onRequest) => {
 	}
 
 	const server = createTlsServer({
+		// Disabled ALPNProtocols to mitigate connection issues in gemini
+		// clients as reported in #5
+		//ALPNProtocols: [ALPN_ID],
 		minVersion: MIN_TLS_VERSION,
 		// > Usually the server specifies in the Server Hello message if a
 		// > client certificate is needed/wanted.

--- a/server.js
+++ b/server.js
@@ -85,7 +85,6 @@ const createGeminiServer = (opt = {}, onRequest) => {
 	}
 
 	const server = createTlsServer({
-		ALPNProtocols: [ALPN_ID],
 		minVersion: MIN_TLS_VERSION,
 		// > Usually the server specifies in the Server Hello message if a
 		// > client certificate is needed/wanted.


### PR DESCRIPTION
When setting the ALPN protocol the gemini browser Kristall won't connect properly. While removing this, per suggestion in #5, connection seems to be working properly.