### PR TITLE
Bug Fix: Use connectTimeout parameter to determine timeout length

### DIFF
--- a/client.js
+++ b/client.js
@@ -178,7 +178,10 @@ const sendGeminiRequest = (pathOrUrl, opt, done) => {
 		hostname: target.hostname || 'localhost',
 		port: target.port || DEFAULT_PORT,
 		connectTimeout,
-		tlsOpt,
+		tlsOpt: {
+			...tlsOpt,
+			servername: target.hostname
+		},
 	}
 
 	if (verifyAlpnId) reqOpt.verifyAlpnId = verifyAlpnId

--- a/client.js
+++ b/client.js
@@ -49,7 +49,7 @@ const _request = (pathOrUrl, opt, ctx, cb) => {
 		const reportTimeout = () => {
 			socket.destroy(new Error('timeout waiting for header'))
 		}
-		let timeout = setTimeout(reportTimeout, 20 * 1000)
+		let timeout = setTimeout(reportTimeout, opt.connectTimeout * 1000)
 
 		res.once('header', (header) => {
 			clearTimeout(timeout)

--- a/client.js
+++ b/client.js
@@ -178,10 +178,7 @@ const sendGeminiRequest = (pathOrUrl, opt, done) => {
 		hostname: target.hostname || 'localhost',
 		port: target.port || DEFAULT_PORT,
 		connectTimeout,
-		tlsOpt: {
-			...tlsOpt,
-			servername: target.hostname
-		},
+		tlsOpt,
 	}
 
 	if (verifyAlpnId) reqOpt.verifyAlpnId = verifyAlpnId

--- a/client.js
+++ b/client.js
@@ -49,7 +49,7 @@ const _request = (pathOrUrl, opt, ctx, cb) => {
 		const reportTimeout = () => {
 			socket.destroy(new Error('timeout waiting for header'))
 		}
-		let timeout = setTimeout(reportTimeout, opt.connectTimeout * 1000)
+		let timeout = setTimeout(reportTimeout, opt.connectTimeout)
 
 		res.once('header', (header) => {
 			clearTimeout(timeout)

--- a/connect.js
+++ b/connect.js
@@ -33,6 +33,7 @@ const connectToGeminiServer = (opt, cb) => {
 		ALPNProtocols: [ALPN_ID],
 		minVersion: MIN_TLS_VERSION,
 		host: hostname,
+		servername: hostname,
 		port,
 		cert, key, passphrase,
 		...tlsOpt,


### PR DESCRIPTION
Without this change, the `connectTimeout` is passed in to the `_request` function, but ignored in favor of a hardcoded value of `20 * 1000` milliseconds. This allows any timeout duration to be set.